### PR TITLE
Fixed FFI function param

### DIFF
--- a/src/UnilangFFI.cpp
+++ b/src/UnilangFFI.cpp
@@ -476,6 +476,7 @@ InitializeFFI(Interpreter& intp)
 		if(IsList(s_param_types_term))
 		{
 			vector<string> s_param_types(term.get_allocator());
+			
 			s_param_types.reserve(s_param_types_term.size());
 			for(const auto& t : s_param_types_term)
 				s_param_types.push_back(Unilang::ResolveRegular<const string>(t));

--- a/src/UnilangFFI.cpp
+++ b/src/UnilangFFI.cpp
@@ -476,8 +476,9 @@ InitializeFFI(Interpreter& intp)
 		if(IsList(s_param_types_term))
 		{
 			vector<string> s_param_types(term.get_allocator());
-
 			s_param_types.reserve(s_param_types_term.size());
+			for(const auto& t : s_param_types_term)
+				s_param_types.push_back(Unilang::ResolveRegular<const string>(t));
 			term.Value = std::allocate_shared<CallInterface>(
 				term.get_allocator(), abi, s_ret_type, s_param_types);
 			return ReductionStatus::Clean;
@@ -512,6 +513,7 @@ InitializeFFI(Interpreter& intp)
 				void* rptr(
 					ystdex::aligned_store_cast<unsigned char*>(p_buf.get()));
 				size_t offset(cif.ret_codec.libffi_type.size);
+				auto i_tm(tm.begin());
 
 				for(size_t idx(0); idx < n_params; ++idx)
 				{
@@ -521,7 +523,7 @@ InitializeFFI(Interpreter& intp)
 					offset = align_offset(offset, t.alignment);
 					p_param_ptrs[idx] = ystdex::aligned_store_cast<
 						unsigned char*>(p_buf.get()) + offset;
-					cif.param_codecs[idx].encode(tm, p_param_ptrs[idx]);
+					cif.param_codecs[idx].encode(*++i_tm, p_param_ptrs[idx]);
 					offset += t.size;
 				}
 				assert(offset == buffer_size);


### PR DESCRIPTION
Fixed FFI ffi-make-call-interface param uncorrectly take effect 
Fixed FFI ffi-make-applicative param encode and compare

Try to use FFI to call Python, and then find that the parameters of the function cannot be loaded correctly.
The function generated by ffi-make-call-interface has no parameters. Fix this problem.
By the way, it also fixes the problem that parameters cannot be encoded correctly in calls generated by ffi-make-applicative.

尝试使用FFI调用Python，然后发现无法正确加载函数的参数，ffi-make-call-interface生成的函数没有参数，修复这个问题，
顺便修复了ffi-make-applicative生成的调用中无法正确解码参数的问题。

Test code:
测试用代码：

def py ffi-load-library "/home/xxxxxx/anaconda3/lib/libpython3.8.so.1.0"
def ffi__void__void ffi-make-call-interface "FFI_DEFAULT_ABI" "void" ()
def ffi__int__string ffi-make-call-interface "FFI_DEFAULT_ABI" "sint" ( list "string" )
def py-PyInitialize ffi-make-applicative py "Py_Initialize" ffi__void__void
def py-PyRun_SimpleString ffi-make-applicative py "PyRun_SimpleString" ffi__int__string

() py-PyInitialize
py-PyRun_SimpleString "print('hello world')"